### PR TITLE
feat: Add ThenGuard and ThenGuardAsync with tests and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- [#209](https://github.com/error-or/error-or/pull/209) Added `ThenGuard` and `ThenGuardAsync` methods.
+
+    They are similar to `ThenEnsure` and `ThenEnsureAsync`, but the guard function can return an `ErrorOr` with a different value type.
+    If no errors are returned, the original value is preserved and the guard function's success value is ignored.
+
 ### Fixed
 
 - [#XXX](https://github.com/error-or/error-or/pull/XXX) Fixed `NullReferenceException` thrown by `ErrorOr<TValue>.GetHashCode()` when the instance is in a success state with a `null` value (including `default(ErrorOr<TValue>)` for reference types). The hash code is now computed via `EqualityComparer<TValue>.Default`, consistent with how `Equals` already handles `null`.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
         - [`ThenAsync`](#thenasync)
         - [`ThenDo` and `ThenDoAsync`](#thendo-and-thendoasync)
         - [`ThenEnsure` and `ThenEnsureAsync`](#thenensure-and-thenensureasync)
+        - [`ThenGuard` and `ThenGuardAsync`](#thenguard-and-thenguardasync)
         - [Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`](#mixing-then-thendo-thenasync-thendoasync)
     - [`FailIf`](#failif)
     - [`Else`](#else)
@@ -602,6 +603,51 @@ ErrorOr<User> userOrError = await _userRepository
 
 // Success: userOrError is the original user from GetByIdAsync.
 // Failure: userOrError contains cache errors from CacheUserAsync.
+```
+
+### `ThenGuard` and `ThenGuardAsync`
+
+`ThenGuard` and `ThenGuardAsync` are similar to `ThenEnsure` and `ThenEnsureAsync`, but the guard function can return an `ErrorOr` with a different value type.
+If no errors are returned, the guard function's success value is ignored and the original value is preserved.
+
+```cs
+ErrorOr<Success> CacheUser(User user) => _cache.Set(user);
+
+ErrorOr<User> userOrError = _userRepository
+    .GetById(userId)
+    .ThenGuard(CacheUser);
+
+// Success: userOrError is the original user from GetById.
+// Failure: userOrError contains cache errors from CacheUser.
+```
+
+`ThenGuard` can be included in a chain, and later methods continue receiving the original value.
+
+```cs
+ErrorOr<string> userNameOrError = _userRepository
+    .GetById(userId)
+    .ThenGuard(CacheUser)
+    .Then(user => user.Name);
+```
+
+```cs
+async Task<ErrorOr<Success>> CacheUserAsync(User user) => await _cache.SetAsync(user);
+
+ErrorOr<User> userOrError = await _userRepository
+    .GetByIdAsync(userId)
+    .ThenGuardAsync(CacheUserAsync);
+
+// Success: userOrError is the original user from GetByIdAsync.
+// Failure: userOrError contains cache errors from CacheUserAsync.
+```
+
+`ThenGuardAsync` can also be included in an asynchronous chain.
+
+```cs
+ErrorOr<string> userNameOrError = await _userRepository
+    .GetByIdAsync(userId)
+    .ThenGuardAsync(CacheUserAsync)
+    .Then(user => user.Name);
 ```
 
 ### Mixing `Then`, `ThenDo`, `ThenAsync`, `ThenDoAsync`

--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ ErrorOr<string> userNameOrError = _userRepository
 ```
 
 ```cs
-async Task<ErrorOr<Success>> CacheUserAsync(User user) => await _cache.SetAsync(user);
+Task<ErrorOr<Success>> CacheUserAsync(User user) => _cache.SetAsync(user);
 
 ErrorOr<User> userOrError = await _userRepository
     .GetByIdAsync(userId)

--- a/src/ErrorOr/ErrorOr.Then.cs
+++ b/src/ErrorOr/ErrorOr.Then.cs
@@ -135,4 +135,42 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
         return result.IsError ? result.Errors : this;
     }
+
+    /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result from invoking the <paramref name="onValue"/> function.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <see cref="ErrorOr"/> instance.</returns>
+    public ErrorOr<TValue> ThenGuard<TResult>(Func<TValue, ErrorOr<TResult>> onValue)
+    {
+        if (IsError)
+        {
+            return Errors;
+        }
+
+        ErrorOr<TResult> result = onValue(Value);
+
+        return result.IsError ? result.Errors : this;
+    }
+
+    /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result from invoking the <paramref name="onValue"/> function.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <see cref="ErrorOr"/> instance.</returns>
+    public async Task<ErrorOr<TValue>> ThenGuardAsync<TResult>(Func<TValue, Task<ErrorOr<TResult>>> onValue)
+    {
+        if (IsError)
+        {
+            return Errors;
+        }
+
+        ErrorOr<TResult> result = await onValue(Value).ConfigureAwait(false);
+
+        return result.IsError ? result.Errors : this;
+    }
 }

--- a/src/ErrorOr/ErrorOr.ThenExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ThenExtensions.cs
@@ -119,4 +119,36 @@ public static partial class ErrorOrExtensions
 
         return await result.ThenEnsureAsync(onValue).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// If the state of <paramref name="errorOr"/> is a value, the provided function <paramref name="onValue"/> is executed and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the result from invoking the <paramref name="onValue"/> function.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <paramref name="errorOr"/>.</returns>
+    public static async Task<ErrorOr<TValue>> ThenGuard<TValue, TResult>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, ErrorOr<TResult>> onValue)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return result.ThenGuard(onValue);
+    }
+
+    /// <summary>
+    /// If the state of <paramref name="errorOr"/> is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its errors are returned.
+    /// If no errors are returned, the original value is returned.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the result from invoking the <paramref name="onValue"/> function.</typeparam>
+    /// <param name="errorOr">The <see cref="ErrorOr"/> instance.</param>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <returns>The errors from calling <paramref name="onValue"/> if state is value and errors are returned; otherwise the original <paramref name="errorOr"/>.</returns>
+    public static async Task<ErrorOr<TValue>> ThenGuardAsync<TValue, TResult>(this Task<ErrorOr<TValue>> errorOr, Func<TValue, Task<ErrorOr<TResult>>> onValue)
+    {
+        var result = await errorOr.ConfigureAwait(false);
+
+        return await result.ThenGuardAsync(onValue).ConfigureAwait(false);
+    }
 }

--- a/tests/ErrorOr/ErrorOr.ThenGuardAsyncTests.cs
+++ b/tests/ErrorOr/ErrorOr.ThenGuardAsyncTests.cs
@@ -1,0 +1,163 @@
+using ErrorOr;
+using FluentAssertions;
+
+namespace Tests;
+
+public class ThenGuardAsyncTests
+{
+    [Fact]
+    public async Task CallingThenGuardAsync_WhenGuardSucceeds_ShouldReturnOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await errorOrInt
+            .ThenGuardAsync(Convert.ToStringAsync);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CallingThenGuardAsync_WhenGuardReturnsError_ShouldReturnGuardErrors()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await errorOrInt
+            .ThenGuardAsync(_ => Task.FromResult(ErrorOrFactory.From<string>(Error.Validation(description: "Guard failed"))));
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("Guard failed");
+    }
+
+    [Fact]
+    public async Task CallingThenGuardAsync_WhenIsError_ShouldNotInvokeGuard()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Error.NotFound();
+        bool called = false;
+
+        // Act
+        ErrorOr<int> result = await errorOrInt
+            .ThenGuardAsync<string>(num =>
+            {
+                called = true;
+                return Task.FromResult<ErrorOr<string>>($"{num}");
+            });
+
+        // Assert
+        called.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public async Task CallingThenGuardAsyncAfterThenAsync_WhenGuardSucceeds_ShouldContinueChainWithOriginalValue()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = "5";
+        int valueFromThenDo = 0;
+
+        // Act
+        ErrorOr<string> result = await errorOrString
+            .ThenAsync(Convert.ToIntAsync)
+            .Then(num => num * 2)
+            .ThenGuardAsync(num => Task.FromResult(ErrorOrFactory.From<string>($"{num + 100}")))
+            .ThenDoAsync(num =>
+            {
+                valueFromThenDo = num;
+                return Task.CompletedTask;
+            })
+            .Then(Convert.ToString);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("10");
+        valueFromThenDo.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task CallingThenGuardAsyncAfterThenAsync_WhenGuardReturnsError_ShouldNotInvokeLaterChain()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = "5";
+        bool thenDoCalled = false;
+        bool thenCalled = false;
+
+        // Act
+        ErrorOr<string> result = await errorOrString
+            .ThenAsync(Convert.ToIntAsync)
+            .Then(num => num + 1)
+            .ThenGuardAsync(_ => Task.FromResult(ErrorOrFactory.From<string>(Error.Validation(description: "Guard failed"))))
+            .ThenDoAsync(_ =>
+            {
+                thenDoCalled = true;
+                return Task.CompletedTask;
+            })
+            .Then(num =>
+            {
+                thenCalled = true;
+                return num.ToString();
+            });
+
+        // Assert
+        thenDoCalled.Should().BeFalse();
+        thenCalled.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("Guard failed");
+    }
+
+    [Fact]
+    public async Task CallingThenGuardAsyncExtensionMethod_WhenGuardSucceeds_ShouldReturnOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await Task.FromResult(errorOrInt)
+            .ThenGuardAsync(Convert.ToStringAsync);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CallingThenGuardAsyncExtensionMethod_WhenGuardReturnsError_ShouldReturnGuardErrors()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await Task.FromResult(errorOrInt)
+            .ThenGuardAsync(_ => Task.FromResult(ErrorOrFactory.From<string>(Error.Validation(description: "Guard failed"))));
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("Guard failed");
+    }
+
+    [Fact]
+    public async Task CallingThenGuardAsyncExtensionMethod_WhenGuardSucceeds_ShouldContinueChainWithOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<string> result = await Task.FromResult(errorOrInt)
+            .ThenGuardAsync(num => Task.FromResult(ErrorOrFactory.From<string>($"{num + 100}")))
+            .ThenAsync(Convert.ToStringAsync);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("5");
+    }
+}

--- a/tests/ErrorOr/ErrorOr.ThenGuardTests.cs
+++ b/tests/ErrorOr/ErrorOr.ThenGuardTests.cs
@@ -1,0 +1,153 @@
+using ErrorOr;
+using FluentAssertions;
+
+namespace Tests;
+
+public class ThenGuardTests
+{
+    [Fact]
+    public void CallingThenGuard_WhenGuardSucceeds_ShouldReturnOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .ThenGuard(Convert.ToString);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void CallingThenGuard_WhenGuardReturnsError_ShouldReturnGuardErrors()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .ThenGuard(_ => ErrorOrFactory.From<string>(Error.Validation(description: "Guard failed")));
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("Guard failed");
+    }
+
+    [Fact]
+    public void CallingThenGuard_WhenIsError_ShouldNotInvokeGuard()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = Error.NotFound();
+        bool called = false;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .ThenGuard<string>(num =>
+            {
+                called = true;
+                return $"{num}";
+            });
+
+        // Assert
+        called.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.NotFound);
+    }
+
+    [Fact]
+    public void CallingThenGuardAfterThen_WhenGuardSucceeds_ShouldContinueChainWithOriginalValue()
+    {
+        // Arrange
+        ErrorOr<string> errorOrString = "5";
+        int valueFromThenDo = 0;
+
+        // Act
+        ErrorOr<string> result = errorOrString
+            .Then(Convert.ToInt)
+            .ThenGuard(num => ErrorOrFactory.From<string>($"{num + 10}"))
+            .ThenDo(num => valueFromThenDo = num)
+            .Then(Convert.ToString);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("5");
+        valueFromThenDo.Should().Be(5);
+    }
+
+    [Fact]
+    public void CallingThenGuardAfterThen_WhenGuardReturnsError_ShouldNotInvokeLaterChain()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+        bool thenDoCalled = false;
+        bool thenCalled = false;
+
+        // Act
+        ErrorOr<int> result = errorOrInt
+            .Then(num => num + 1)
+            .ThenGuard(_ => ErrorOrFactory.From<string>(Error.Validation(description: "Guard failed")))
+            .ThenDo(_ => thenDoCalled = true)
+            .Then(num =>
+            {
+                thenCalled = true;
+                return num * 2;
+            });
+
+        // Assert
+        thenDoCalled.Should().BeFalse();
+        thenCalled.Should().BeFalse();
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("Guard failed");
+    }
+
+    [Fact]
+    public async Task CallingThenGuardExtensionMethod_WhenGuardSucceeds_ShouldReturnOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await Task.FromResult(errorOrInt)
+            .ThenGuard(Convert.ToString);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CallingThenGuardExtensionMethod_WhenGuardReturnsError_ShouldReturnGuardErrors()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<int> result = await Task.FromResult(errorOrInt)
+            .ThenGuard(_ => ErrorOrFactory.From<string>(Error.Validation(description: "Guard failed")));
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.FirstError.Type.Should().Be(ErrorType.Validation);
+        result.FirstError.Description.Should().Be("Guard failed");
+    }
+
+    [Fact]
+    public async Task CallingThenGuardExtensionMethod_WhenGuardSucceeds_ShouldContinueChainWithOriginalValue()
+    {
+        // Arrange
+        ErrorOr<int> errorOrInt = 5;
+
+        // Act
+        ErrorOr<string> result = await Task.FromResult(errorOrInt)
+            .ThenGuard(num => ErrorOrFactory.From<string>($"{num + 100}"))
+            .Then(Convert.ToString);
+
+        // Assert
+        result.IsError.Should().BeFalse();
+        result.Value.Should().Be("5");
+    }
+}


### PR DESCRIPTION
Currently, `ThenEnsure` requires ErrorOr side-effecting functions to return the same value type as the original `ErrorOr<TValue>`. However, the success result of these functions is discarded while their errors are captured. There is a gap where one cannot perform a side-effecting function returning a different success type without first mapping that success result back to the original value.

Below is an example of how `ThenGuard` works in consumers.

```csharp
// cache.Set returns an ErrorOr<Success>

ErrorOr<User> userOrError = repository
    .GetById(userId)
    .ThenGuard(cache.Set);
```

As another example, the consumer can capture an error from an asynchronous side-effecting function while preserving the original value for later operations in the chain.

```csharp
// cache.SetAsync returns Task<ErrorOr<Success>>

ErrorOr<string> userNameOrError = await repository
    .GetByIdAsync(userId)
    .ThenGuardAsync(cache.SetAsync)
    .Then(user => user.Name);
```

The proposal introduces a new "guard" step to the `ErrorOr` monadic pipeline. The new `ThenGuard` and `ThenGuardAsync` methods, and their extension counterparts, allow consumers to capture errors from functions returning `ErrorOr<TResult>` while preserving the original value if no errors are returned. This is additive and keeps the existing `ThenEnsure` API unchanged.

Additions to the ErrorOr pipeline:

* Added `ThenGuard<TResult>` and `ThenGuardAsync<TResult>` methods to `ErrorOr<TValue>`, allowing side-effecting functions with a different success result type to be injected into the pipeline. These methods return errors if the provided function does, or preserve the original value otherwise.
* Added extension methods `ThenGuard<TValue, TResult>` and `ThenGuardAsync<TValue, TResult>` for `Task<ErrorOr<TValue>>`, supporting asynchronous pipelines with guard steps.

Documentation updates:

* Updated `README.md` to document the new `ThenGuard` and `ThenGuardAsync` methods, including standalone and chained synchronous and asynchronous usage examples.

Testing:

* Added unit tests for `ThenGuard` in `tests/ErrorOr/ErrorOr.ThenGuardTests.cs`, covering successful guards, error cases, existing error states, extension methods, and chained usage.
* Added unit tests for `ThenGuardAsync` in `tests/ErrorOr/ErrorOr.ThenGuardAsyncTests.cs`, covering asynchronous guards, error cases, existing error states, extension methods, and chained usage.

Validation:

* `dotnet build ErrorOr.slnx --no-restore`
* `dotnet test tests/Tests.csproj --framework net8.0 --no-restore`
* `dotnet test tests/Tests.csproj --framework net10.0 --no-restore`
